### PR TITLE
Principal Component Analysis

### DIFF
--- a/recipes/DR/pca.py
+++ b/recipes/DR/pca.py
@@ -53,6 +53,8 @@ class PCA:
         #self.eigvals = eigvals[-self.n_components:]
         #self.eigvecs = eigvecs[:, -self.n_components:]
 
+        # Stores all the eigenvectors/eigenvalues
+        # Usefull for latter computing some statistics of the variance we keep
         self.eigvals = eigvals
         self.eigvecs = eigvecs
 
@@ -78,7 +80,7 @@ if __name__ == '__main__':
 
     N = 500
 
-    # Generate some random normal data rotated and translated
+    ## Generate some random normal data rotated and translated
     X = np.column_stack([np.random.normal(0.0, 1.0, (N, )),
                          np.random.normal(0.0, 0.2, (N, ))])
     X = np.dot(X, np.array([[np.cos(1.0), np.sin(1.0)],[-np.sin(1.0), np.cos(1.0)]]))
@@ -90,6 +92,7 @@ if __name__ == '__main__':
     pca = PCA(n_components=n_components)
     pca.fit(X)
 
+    ## Project the original data
     X_trans = pca.transform(X)
 
     print("{}% of the variance along the first axis (green)".format(

--- a/recipes/DR/pca.py
+++ b/recipes/DR/pca.py
@@ -95,10 +95,10 @@ if __name__ == '__main__':
     ## Project the original data
     X_trans = pca.transform(X)
 
-    print("{}% of the variance along the first axis (green)".format(
+    print("{:.2f}% of the variance along the first axis (green)".format(
           100 * pca.eigvals[-1] / pca.eigvals.sum()))
 
-    print("{}% of the variance along the second axis (red)".format(
+    print("{:.2f}% of the variance along the second axis (red)".format(
           100 * pca.eigvals[-2] / pca.eigvals.sum()))
 
     ## Plot
@@ -115,6 +115,8 @@ if __name__ == '__main__':
     plt.xlim([-3, 3])
     plt.ylim([-3, 3])
     plt.gca().set_aspect('equal')
+    plt.savefig("random_points.png")
+    print()
 
     # Example 2 : 28 x 28 images of digits
     # -------------------------------------------------------------------------
@@ -132,7 +134,7 @@ if __name__ == '__main__':
     ## Project the original data
     X_trans = pca.transform(X)
 
-    print("{}% of the variance is kept with {} components".format(
+    print("{:.2f}% of the variance is kept with {} components".format(
           100 * pca.eigvals[-n_components:].sum()/pca.eigvals.sum(),
           n_components))
 
@@ -161,4 +163,5 @@ if __name__ == '__main__':
         ax.set_xticks([])
         ax.set_yticks([])
 
+    plt.savefig("digits.png")
     plt.show()

--- a/recipes/DR/pca.py
+++ b/recipes/DR/pca.py
@@ -1,0 +1,89 @@
+# -----------------------------------------------------------------------------
+# Copyright 2019 (C) Jeremy Fix
+# Released under a BSD two-clauses license
+#
+# Reference: Pearson, K. (1901). "On Lines and Planes of Closest Fit to Systems
+#            of Points in Space". Philosophical Magazine. 2 (11): 559–572.
+#            doi:10.1080/14786440109462720
+# -----------------------------------------------------------------------------
+import numpy as np
+import matplotlib.pyplot as plt
+
+class PCA:
+    ''' PCA class '''
+
+    def __init__(self, n_components):
+        self.n_components = n_components
+
+    def fit(self, X):
+        '''
+        Performs the PCA of X and stores the principal components.
+        The datapoints are supposed to be stored in the row vectors of X.
+        It keeps only the n_components projection vectors, associated
+        with the n_components largest eigenvalues of the covariance matrix X.T X
+        '''
+
+        # Center the datapoints
+        self.centroid = np.mean(X, axis=0)
+
+        # Computes the covariance matrix
+        sigma = np.dot((X - self.centroid).T, X - self.centroid)
+
+        # Compute the eigenvalue/eigenvector decomposition of sigma
+        eigvals, eigvecs = np.linalg.eigh(sigma)
+
+        # Note :The eigenvalues returned by eigh are ordered in ascending order.
+
+        # Stores the n_components eigvenvectors/eigenvalues associated
+        # with the largest eigen values
+        self.eigvals = eigvals[-self.n_components:]
+        self.eigvecs = eigvecs[:, -self.n_components:]
+
+    def transform(self, Z):
+        '''
+        Uses a fitted PCA to transform the row vectors of Z
+        Remember the eigen vectors are ordred by ascending order
+        Denoting Z_trans = transform(Z),
+        The first  component is Z_trans[:, -1]
+        The second component is Z_trans[:, -2]
+        ...
+        '''
+        print((Z-self.centroid).shape, self.eigvecs.shape)
+        return np.dot(Z - self.centroid, self.eigvecs)
+
+
+if __name__ == '__main__':
+
+    N = 500
+    # Generate some random normal data rotated and translated
+    X = np.column_stack([np.random.normal(0.0, 1.0, (N, )),
+                         np.random.normal(0.0, 0.2, (N, ))])
+    X = np.dot(X, np.array([[np.cos(1.0), np.sin(1.0)],[-np.sin(1.0), np.cos(1.0)]]))
+    X = np.array([0.5, 1.0]) + X
+
+    # Computes the PCA
+    pca = PCA(n_components=2)
+    pca.fit(X)
+
+    X_trans = pca.transform(X)
+
+    # Plot
+    plt.figure()
+    plt.scatter(X[:,0], X[:,1])
+    # First axis
+    plt.plot([pca.centroid[0]-2*pca.eigvecs[0, -1], pca.centroid[0]+2*pca.eigvecs[0,-1]],
+             [pca.centroid[1]-2*pca.eigvecs[1, -1], pca.centroid[1]+2*pca.eigvecs[1,-1]],
+             'g', linewidth=3)
+    # Second axis
+    plt.plot([pca.centroid[0]-2*pca.eigvecs[0, 0], pca.centroid[0]+2*pca.eigvecs[0,0]],
+             [pca.centroid[1]-2*pca.eigvecs[1, 0], pca.centroid[1]+2*pca.eigvecs[1,0]],
+             'r', linewidth=3)
+    plt.xlim([-3, 3])
+    plt.ylim([-3, 3])
+    plt.gca().set_aspect('equal')
+
+
+    plt.figure()
+    plt.scatter(X_trans[:, -1], X_trans[:, -2])
+
+    plt.show()

--- a/recipes/DR/pca.py
+++ b/recipes/DR/pca.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
 
     ## Plot
     plt.figure()
-    plt.scatter(X[:,0], X[:,1])
+    plt.scatter(X[:,0], X[:,1], alpha = .25)
     ## Plot the first projecton axis in green
     plt.plot([pca.centroid[0]-2*pca.eigvecs[0, -1], pca.centroid[0]+2*pca.eigvecs[0,-1]],
              [pca.centroid[1]-2*pca.eigvecs[1, -1], pca.centroid[1]+2*pca.eigvecs[1,-1]],
@@ -146,7 +146,7 @@ if __name__ == '__main__':
     ### the color shows how the digits get separated by the principal vectors
     ax = fig.add_subplot(gs[0:2, :-2])
     cmap = get_cmap(10)
-    ax.scatter(X_trans[:, -1], X_trans[:,-2] , c=[cmap(l) for l in y])
+    ax.scatter(X_trans[:, -1], X_trans[:,-2] , c=[cmap(l) for l in y], alpha = .25)
     ax = fig.add_subplot(gs[0:2, -2:])
     ax.set_axis_off()
     for i in range(10):


### PR DESCRIPTION
I propose to open a "Dimensionality Reduction" section and this PR provides a simple script computing the PCA with two illustrations :
- with random points in 2D to illustrate the projection vectors that are computed
- with 28x28 digits projected in 2D. The top plot shows the digits projected in the space spanned by the first 2 principal vectors. The bottom plot shows the projection vectors and permit to make sense of the top plot since the vectors clearly indicate the digits they separate.